### PR TITLE
Replace naive recursion with dynamic loop, performance bump from exponential to linear time

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ sbt "run 7"
 sbt "run 17"
 
 >10926
+# Don't do this in recursive (main) branch 
+# unless you have 1000000000000 years to wait
 sbt "run 90"
 
 >19740274219868223074
@@ -74,9 +76,9 @@ run 7
 run 17
 
 >10926
+# Don't do this in recursive (main) branch 
+# unless you have 1000000000000 years to wait
 run 90
 
 >19740274219868223074
 ```
-
-I have no idea how long my 7 year old economy laptop will take to calculate specialMath(90) <3.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@
 - Ruby: 3
 - Angular: 3
 - Helm: 2
-- Terraform: 2
+- Terraform: 3
 - MQL (MongoDB Query Language): 3
 - SQL: 2
+
+### Honerable Mentions:
+- CloudFormation: 1
+- Ansible: 1
+- Bash: 1
+- Powershell: 1.5
 
 ## Repo Contents:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ sbt "run 7"
 sbt "run 17"
 
 >10926
+sbt "run 90"
+
+>19740274219868223074
 ```
 SBT shell:
 ```sh
@@ -65,6 +68,9 @@ run 7
 run 17
 
 >10926
+run 90
+
+>19740274219868223074
 ```
 
-I have no idea how long my 7 year old economy laptop will take to calculate specialMath(90) <3
+I have no idea how long my 7 year old economy laptop will take to calculate specialMath(90) <3.

--- a/hexrad/src/main/scala/Main.scala
+++ b/hexrad/src/main/scala/Main.scala
@@ -8,6 +8,9 @@ object Main extends App {
     sys.exit(1)
   }
   else {
+    if(args(0).length % 2 != 0) {
+      println("Odd length input not valid hexidecimal representation")
+    }
     try {
       println(encode_hex(args(0)))
     } catch {
@@ -31,7 +34,7 @@ object Main extends App {
   // This is much better than the old method
   // because:
   //  it only uses O(1) memory
-  //  It The overflow limit is the ssize limit of Array and ArrayBuffer
+  //  the overflow limit is the size limit of Array and ArrayBuffer and not BigInteger
   def hex_2_bytes(input:String):Array[Byte] = {
     val bytes:ArrayBuffer[Byte] = ArrayBuffer[Byte]() 
     for (byte_string <- input.grouped(2)) {

--- a/specialmath/src/main/scala/Main.scala
+++ b/specialmath/src/main/scala/Main.scala
@@ -1,3 +1,5 @@
+import java.math.BigInteger
+
 object Main extends App {
   if( args.length != 1) {
     // Checks for missing input
@@ -5,7 +7,7 @@ object Main extends App {
     sys.exit(1)
   } else {
     try {
-      val input_n:Int = Integer.parseInt(args(0))
+      val input_n:BigInt = new BigInt(new BigInteger(args(0)))
       println(specialMath(input_n))
     } catch {
       // Checks for parse error due to invalid input
@@ -15,9 +17,16 @@ object Main extends App {
       }
     } 
   }
-  // my poor little laptoop cannot do f(90)
-  def specialMath(n:Long):Long = {
-      if(n==0) 0 else if(n==1) 1 else 
-      n + specialMath(n-1)	+ specialMath(n-2)
-  }
+  // my poor little laptop cannot do f(90) which is at least O((3/2)**90) time
+  def specialMath(n:BigInt):BigInt = {
+      var sum:BigInt = 0
+      var minus_two:BigInt = 0
+      var minus_one:BigInt = 1   
+      for(i <- 2 to n.toInt) {
+        sum = i + minus_one + minus_two
+        minus_two = minus_one
+        minus_one = sum
+      } 
+      sum
+    }
 }

--- a/specialmath/src/main/scala/Main.scala
+++ b/specialmath/src/main/scala/Main.scala
@@ -17,7 +17,6 @@ object Main extends App {
       }
     } 
   }
-  // my poor little laptop cannot do f(90) which is at least O((3/2)**90) time
   def specialMath(n:BigInt):BigInt = {
       var sum:BigInt = 0
       var minus_two:BigInt = 0


### PR DESCRIPTION
Replaced the naive recursive version of `specialMath` with a dynamic loop that produces the same output. The naive method had performance worse than `O(1.5^n)`, while the dynamic loop has `O(n)` time complexity.